### PR TITLE
Feature/graphqlgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ SubstanceGen provides an interface for implementations to use data produced by S
 
 ## SubstanceGen Code Generators
 
-- GraphQL Type Schema via `gqlschema`
-- GraphQL-Go Server _planned_
+- GraphQL-Go Server 
 - GoStructs _planned_
 - GORM _planned_

--- a/providers/pgsqlsubstance/pgsqlsubstance.go
+++ b/providers/pgsqlsubstance/pgsqlsubstance.go
@@ -3,9 +3,10 @@ package pgsqlsubstance
 import (
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
-	"regexp"
+
 	"github.com/ahmedalhulaibi/substance"
 )
 
@@ -13,7 +14,6 @@ func init() {
 	pgsqlPlugin := pgsql{}
 	substance.Register("postgres", &pgsqlPlugin)
 }
-
 
 type pgsql struct {
 	name string
@@ -219,7 +219,7 @@ func (p pgsql) DescribeTableRelationshipFunc(dbType string, connectionString str
 			//fmt.Printf("DescribeTableRelationshipFunc Value %T ", value)
 			switch value.(type) {
 			case string:
-				fmt.Println("\t", columns[i], ": ", value)
+				//fmt.Println("\t", columns[i], ": ", value)
 				switch columns[i] {
 				case "table_name":
 					newColDesc.TableName = string(value.(string))
@@ -227,7 +227,7 @@ func (p pgsql) DescribeTableRelationshipFunc(dbType string, connectionString str
 					newColDesc.ColumnName = string(value.(string))
 				}
 			case []byte:
-				fmt.Println("\t", columns[i], ": ", string(value.([]byte)))
+				//fmt.Println("\t", columns[i], ": ", string(value.([]byte)))
 
 				switch columns[i] {
 				case "ref_table":
@@ -321,10 +321,9 @@ func (p pgsql) DescribeTableConstraintsFunc(dbType string, connectionString stri
 	return columnDesc, nil
 }
 
-
-func (p pgsql) GetGoDataType (sqlType string) (string, error) {
+func (p pgsql) GetGoDataType(sqlType string) (string, error) {
 	for pattern, value := range regexDataTypePatterns {
-		match, err := regexp.MatchString(pattern,sqlType)
+		match, err := regexp.MatchString(pattern, sqlType)
 		if match && err == nil {
 			result := value
 			return result, nil

--- a/providers/pgsqlsubstance/pgsqlsubstance.go
+++ b/providers/pgsqlsubstance/pgsqlsubstance.go
@@ -28,12 +28,8 @@ func (p pgsql) GetCurrentDatabaseNameFunc(dbType string, connectionString string
 
 /*DescribeDatabase returns tables in database*/
 func (p pgsql) DescribeDatabaseFunc(dbType string, connectionString string) ([]substance.ColumnDescription, error) {
-	//prepend postgres:// to connection string
-	postgresString := "postgres://"
-	connString := postgresString + connectionString
-
 	//opening connection
-	db, err := sql.Open(dbType, connString)
+	db, err := sql.Open(dbType, connectionString)
 	defer db.Close()
 	if err != nil {
 		return nil, err
@@ -98,9 +94,7 @@ func (p pgsql) DescribeDatabaseFunc(dbType string, connectionString string) ([]s
 
 /*DescribeTable returns columns in database*/
 func (p pgsql) DescribeTableFunc(dbType string, connectionString string, tableName string) ([]substance.ColumnDescription, error) {
-	postgresString := "postgres://"
-	connString := postgresString + connectionString
-	db, err := sql.Open(dbType, connString)
+	db, err := sql.Open(dbType, connectionString)
 	defer db.Close()
 	if err != nil {
 		return nil, err
@@ -171,9 +165,7 @@ func (p pgsql) DescribeTableFunc(dbType string, connectionString string, tableNa
 
 /*DescribeTableRelationship returns all foreign column references in database table*/
 func (p pgsql) DescribeTableRelationshipFunc(dbType string, connectionString string, tableName string) ([]substance.ColumnRelationship, error) {
-	postgresString := "postgres://"
-	connString := postgresString + connectionString
-	db, err := sql.Open(dbType, connString)
+	db, err := sql.Open(dbType, connectionString)
 	defer db.Close()
 	if err != nil {
 		return nil, err
@@ -258,9 +250,7 @@ func (p pgsql) DescribeTableRelationshipFunc(dbType string, connectionString str
 }
 
 func (p pgsql) DescribeTableConstraintsFunc(dbType string, connectionString string, tableName string) ([]substance.ColumnConstraint, error) {
-	postgresString := "postgres://"
-	connString := postgresString + connectionString
-	db, err := sql.Open(dbType, connString)
+	db, err := sql.Open(dbType, connectionString)
 	defer db.Close()
 	if err != nil {
 		return nil, err

--- a/substancegen/generators/gqlschema/codeGeneration.go
+++ b/substancegen/generators/gqlschema/codeGeneration.go
@@ -1,0 +1,61 @@
+package gqlgraphqlator
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/ahmedalhulaibi/substance/substancegen"
+)
+
+func (g gql) OutputCodeFunc(gqlObjectTypes map[string]substancegen.GenObjectType) bytes.Buffer {
+	var buff bytes.Buffer
+	//print schema
+	for _, value := range gqlObjectTypes {
+		for _, propVal := range value.Properties {
+			propVal.Tags["json"] = append(propVal.Tags["json"], propVal.ScalarName)
+		}
+		g.GenObjectTypeToStringFunc(value, &buff)
+		g.GenGormObjectTableNameOverrideFunc(value, &buff)
+	}
+	fmt.Print(buff.String())
+	return buff
+}
+
+func (g gql) GenObjectTypeToStringFunc(gqlObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
+	buff.WriteString(fmt.Sprintf("\ntype %s struct {\n", strings.TrimSuffix(gqlObjectType.Name, "s")))
+	for _, property := range gqlObjectType.Properties {
+		g.GenObjectPropertyToStringFunc(property, buff)
+	}
+	buff.WriteString("}\n")
+}
+
+func (g gql) GenObjectPropertyToStringFunc(gqlObjectProperty substancegen.GenObjectProperty, buff *bytes.Buffer) {
+	if gqlObjectProperty.IsList {
+		buff.WriteString(fmt.Sprintf("\t%s\t[]%s\t", gqlObjectProperty.ScalarName, gqlObjectProperty.ScalarType))
+	} else {
+		buff.WriteString(fmt.Sprintf("\t%s\t%s\t", gqlObjectProperty.ScalarName, gqlObjectProperty.ScalarType))
+	}
+	g.GenObjectTagToStringFunc(gqlObjectProperty.Tags, buff)
+	buff.WriteString("\n")
+}
+
+func (g gql) GenObjectTagToStringFunc(genObjectTags substancegen.GenObjectTag, buff *bytes.Buffer) {
+	buff.WriteString("`")
+	for key, tags := range genObjectTags {
+		buff.WriteString(fmt.Sprintf("%s:\"", key))
+		for _, tag := range tags {
+			buff.WriteString(fmt.Sprintf("%s", tag))
+		}
+		buff.WriteString("\" ")
+	}
+	buff.WriteString("`")
+}
+
+func (g gql) GenGormObjectTableNameOverrideFunc(gqlObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
+	buff.WriteString(fmt.Sprintf("\nfunc (%s) TableName() string {\n\treturn \"%s\"\n}\n", strings.TrimSuffix(gqlObjectType.Name, "s"), gqlObjectType.Name))
+}
+
+func (g gql) GenGraphqlGoTypesFunc(gqlObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
+	buff.WriteString(fmt.Sprintf(""))
+}

--- a/substancegen/generators/gqlschema/gqlschema.go
+++ b/substancegen/generators/gqlschema/gqlschema.go
@@ -1,7 +1,6 @@
 package gqlgraphqlator
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 
@@ -213,49 +212,6 @@ func (g gql) ResolveRelationshipsFunc(dbType string, connectionString string, ta
 		}
 	}
 	return gqlObjectTypes
-}
-
-func (g gql) OutputCodeFunc(gqlObjectTypes map[string]substancegen.GenObjectType) bytes.Buffer {
-	var buff bytes.Buffer
-	//print schema
-	for _, value := range gqlObjectTypes {
-		for _, propVal := range value.Properties {
-			propVal.Tags["json"] = append(propVal.Tags["json"], propVal.ScalarName)
-		}
-		g.GenObjectTypeToStringFunc(value, &buff)
-	}
-	fmt.Print(buff.String())
-	return buff
-}
-
-func (g gql) GenObjectTypeToStringFunc(gqlObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
-	buff.WriteString(fmt.Sprintf("\ntype %s struct {\n", strings.TrimSuffix(gqlObjectType.Name, "s")))
-	for _, property := range gqlObjectType.Properties {
-		g.GenObjectPropertyToStringFunc(property, buff)
-	}
-	buff.WriteString("}\n")
-}
-
-func (g gql) GenObjectPropertyToStringFunc(gqlObjectProperty substancegen.GenObjectProperty, buff *bytes.Buffer) {
-	if gqlObjectProperty.IsList {
-		buff.WriteString(fmt.Sprintf("\t%s\t[]%s\t", gqlObjectProperty.ScalarName, gqlObjectProperty.ScalarType))
-	} else {
-		buff.WriteString(fmt.Sprintf("\t%s\t%s\t", gqlObjectProperty.ScalarName, gqlObjectProperty.ScalarType))
-	}
-	g.GenObjectTagToStringFunc(gqlObjectProperty.Tags, buff)
-	buff.WriteString("\n")
-}
-
-func (g gql) GenObjectTagToStringFunc(genObjectTags substancegen.GenObjectTag, buff *bytes.Buffer) {
-	buff.WriteString("`")
-	for key, tags := range genObjectTags {
-		buff.WriteString(fmt.Sprintf("%s:\"", key))
-		for _, tag := range tags {
-			buff.WriteString(fmt.Sprintf("%s", tag))
-		}
-		buff.WriteString("\" ")
-	}
-	buff.WriteString("`")
 }
 
 func stringInSlice(searchVal string, list []string) bool {

--- a/substancegen/generators/graphqlgo/codeGeneration.go
+++ b/substancegen/generators/graphqlgo/codeGeneration.go
@@ -1,4 +1,4 @@
-package gqlgraphqlator
+package graphqlgo
 
 import (
 	"bytes"

--- a/substancegen/generators/graphqlgo/codeGeneration.go
+++ b/substancegen/generators/graphqlgo/codeGeneration.go
@@ -111,6 +111,8 @@ func (g gql) GenGraphqlGoTypePropertyFunc(gqlObjectProperty substancegen.GenObje
 
 func (g gql) GenGraphqlGoMainFunc(dbType string, connectionString string, gqlObjectTypes map[string]substancegen.GenObjectType, buff *bytes.Buffer) {
 	buff.WriteString(fmt.Sprintf("\nfunc main() {\n\n\tdb, err := gorm.Open(\"%s\",\"%s\")\n\tdefer db.Close()\n\n\t", dbType, connectionString))
+	sampleQuery := g.GenGraphqlGoSampleQuery(gqlObjectTypes)
+	buff.WriteString(fmt.Sprintf("\n\tfmt.Println(\"Test with Get\t: curl -g 'http://localhost:8080/graphql?query={%s}'\")", sampleQuery.String()))
 
 	buff.WriteString("\n\tfields := graphql.Fields{")
 	for _, value := range gqlObjectTypes {
@@ -118,9 +120,7 @@ func (g gql) GenGraphqlGoMainFunc(dbType string, connectionString string, gqlObj
 	}
 	buff.WriteString("\n\t\t}")
 	buff.WriteString(GraphqlGoMainConfig)
-	sampleQuery := g.GenGraphqlGoSampleQuery(gqlObjectTypes)
 
-	buff.WriteString(fmt.Sprintf("\n\tfmt.Println(\"Test with Get\t: curl -g 'http://localhost:8080/graphql?query={%s}'\")", sampleQuery.String()))
 	buff.WriteString("\n}\n")
 }
 

--- a/substancegen/generators/graphqlgo/codeGeneration.go
+++ b/substancegen/generators/graphqlgo/codeGeneration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/ahmedalhulaibi/substance/substancegen"
 )
@@ -17,13 +18,15 @@ func (g gql) OutputCodeFunc(gqlObjectTypes map[string]substancegen.GenObjectType
 		}
 		g.GenObjectTypeToStringFunc(value, &buff)
 		g.GenGormObjectTableNameOverrideFunc(value, &buff)
+		g.GenGraphqlGoTypeFunc(value, &buff)
 	}
 	fmt.Print(buff.String())
 	return buff
 }
 
 func (g gql) GenObjectTypeToStringFunc(gqlObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
-	buff.WriteString(fmt.Sprintf("\ntype %s struct {\n", strings.TrimSuffix(gqlObjectType.Name, "s")))
+	gqlObjectTypeNameSingular := strings.TrimSuffix(gqlObjectType.Name, "s")
+	buff.WriteString(fmt.Sprintf("\ntype %s struct {\n", gqlObjectTypeNameSingular))
 	for _, property := range gqlObjectType.Properties {
 		g.GenObjectPropertyToStringFunc(property, buff)
 	}
@@ -53,9 +56,54 @@ func (g gql) GenObjectTagToStringFunc(genObjectTags substancegen.GenObjectTag, b
 }
 
 func (g gql) GenGormObjectTableNameOverrideFunc(gqlObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
-	buff.WriteString(fmt.Sprintf("\nfunc (%s) TableName() string {\n\treturn \"%s\"\n}\n", strings.TrimSuffix(gqlObjectType.Name, "s"), gqlObjectType.Name))
+	gqlObjectTypeNameSingular := strings.TrimSuffix(gqlObjectType.Name, "s")
+	buff.WriteString(fmt.Sprintf("\nfunc (%s) TableName() string {\n\treturn \"%s\"\n}\n", gqlObjectTypeNameSingular, gqlObjectType.Name))
 }
 
-func (g gql) GenGraphqlGoTypesFunc(gqlObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
-	buff.WriteString(fmt.Sprintf(""))
+func (g gql) GenGraphqlGoTypeFunc(gqlObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
+	a := []rune(strings.TrimSuffix(gqlObjectType.Name, "s"))
+	a[0] = unicode.ToLower(a[0])
+	gqlObjectTypeNameLowCamel := string(a)
+	gqlObjectTypeNameSingular := strings.TrimSuffix(gqlObjectType.Name, "s")
+	buff.WriteString(fmt.Sprintf("\nvar %sType = graphql.NewObject(\n\tgraphql.ObjectConfig{\n\t\tName: \"%s\",\n\t\tFields: graphql.Fields{\n\t\t\t", gqlObjectTypeNameLowCamel, gqlObjectTypeNameSingular))
+
+	for _, property := range gqlObjectType.Properties {
+		g.GenGraphqlGoTypePropertyFunc(property, buff)
+	}
+
+	buff.WriteString(fmt.Sprintf("\n\t\t},\n\t},\n)\n"))
+}
+
+func (g gql) GenGraphqlGoTypePropertyFunc(gqlObjectProperty substancegen.GenObjectProperty, buff *bytes.Buffer) {
+	var gqlPropertyTypeName string
+	if gqlObjectProperty.IsObjectType {
+		a := []rune(strings.TrimSuffix(gqlObjectProperty.ScalarName, "s"))
+		a[0] = unicode.ToLower(a[0])
+		gqlPropertyTypeName = fmt.Sprintf("%sType", string(a))
+	} else {
+		gqlPropertyTypeName = g.GetGraphqlDataType(gqlObjectProperty.ScalarType)
+	}
+
+	buff.WriteString(fmt.Sprintf("\n\t\t\t\"%s\": &graphql.Field{\n\t\t\t\tType: %s,\n\t\t\t},", gqlObjectProperty.ScalarName, gqlPropertyTypeName))
+}
+
+func (g gql) GetGraphqlDataType(goDataType string) string {
+	graphqlTypes := make(map[string]string)
+	graphqlTypes["int"] = "graphql.Int"
+	graphqlTypes["int8"] = "graphql.Int"
+	graphqlTypes["int16"] = "graphql.Int"
+	graphqlTypes["int32"] = "graphql.Int"
+	graphqlTypes["int64"] = "graphql.Int"
+	graphqlTypes["uint"] = "graphql.Int"
+	graphqlTypes["uint8"] = "graphql.Int"
+	graphqlTypes["uint16"] = "graphql.Int"
+	graphqlTypes["uint32"] = "graphql.Int"
+	graphqlTypes["uint64"] = "graphql.Int"
+	graphqlTypes["byte"] = "graphql.Int"
+	graphqlTypes["rune"] = "graphql.Int"
+	graphqlTypes["bool"] = "graphql.Boolean"
+	graphqlTypes["string"] = "graphql.String"
+	graphqlTypes["float32"] = "graphql.Float"
+	graphqlTypes["float64"] = "graphql.Float"
+	return graphqlTypes[goDataType]
 }

--- a/substancegen/generators/graphqlgo/graphqlgo.go
+++ b/substancegen/generators/graphqlgo/graphqlgo.go
@@ -1,4 +1,4 @@
-package gqlgraphqlator
+package graphqlgo
 
 import (
 	"fmt"

--- a/substancegen/generators/graphqlgo/graphqlgo.go
+++ b/substancegen/generators/graphqlgo/graphqlgo.go
@@ -188,10 +188,11 @@ func (g gql) ResolveRelationshipsFunc(dbType string, connectionString string, ta
 			gormTagForeign := "ForeignKey:" + colRel.ColumnName + ";"
 			gormTagAssociationForeign := "AssociationForeignKey:" + colRel.ReferenceColumnName + ";"
 			newGqlObjProperty := substancegen.GenObjectProperty{
-				ScalarName: colRel.TableName,
-				ScalarType: strings.TrimSuffix(colRel.TableName, "s"),
-				Nullable:   true,
-				IsList:     true,
+				ScalarName:   colRel.TableName,
+				ScalarType:   strings.TrimSuffix(colRel.TableName, "s"),
+				Nullable:     true,
+				IsList:       true,
+				IsObjectType: true,
 			}
 			newGqlObjProperty.Tags = make(substancegen.GenObjectTag)
 			newGqlObjProperty.Tags["gorm"] = append(newGqlObjProperty.Tags["gorm"], gormTagForeign, gormTagAssociationForeign)
@@ -200,10 +201,11 @@ func (g gql) ResolveRelationshipsFunc(dbType string, connectionString string, ta
 			gormTagForeign := "ForeignKey:" + colRel.ColumnName + ";"
 			gormTagAssociationForeign := "AssociationForeignKey:" + colRel.ReferenceColumnName + ";"
 			newGqlObjProperty := substancegen.GenObjectProperty{
-				ScalarName: strings.TrimSuffix(colRel.TableName, "s"),
-				ScalarType: strings.TrimSuffix(colRel.TableName, "s"),
-				Nullable:   true,
-				IsList:     false,
+				ScalarName:   strings.TrimSuffix(colRel.TableName, "s"),
+				ScalarType:   strings.TrimSuffix(colRel.TableName, "s"),
+				Nullable:     true,
+				IsList:       false,
+				IsObjectType: true,
 			}
 			newGqlObjProperty.Tags = make(substancegen.GenObjectTag)
 			newGqlObjProperty.Tags["gorm"] = append(newGqlObjProperty.Tags["gorm"], gormTagForeign, gormTagAssociationForeign)

--- a/substancegen/generators/graphqlgo/graphqlgoTemplates.go
+++ b/substancegen/generators/graphqlgo/graphqlgoTemplates.go
@@ -1,0 +1,14 @@
+package graphqlgo
+
+var packageNameTemplate string = `package main\n`
+
+var mainImportTemplate string = `import (
+	"encoding/json"
+	"fmt"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/graphql-go/graphql"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/mysql"
+	"log"
+	"net/http"
+)\n`

--- a/substancegen/substancegen.go
+++ b/substancegen/substancegen.go
@@ -25,12 +25,13 @@ type GenObjectTag map[string][]string
 
 /*GenObjectProperty placeholder comment */
 type GenObjectProperty struct {
-	ScalarName string
-	ScalarType string
-	IsList     bool
-	Nullable   bool
-	KeyType    []string
-	Tags       GenObjectTag
+	ScalarName   string
+	ScalarType   string
+	IsList       bool
+	Nullable     bool
+	KeyType      []string
+	Tags         GenObjectTag
+	IsObjectType bool
 }
 
 /*GenObjectProperties placeholder comment */

--- a/substancegen/substancegen.go
+++ b/substancegen/substancegen.go
@@ -1,10 +1,17 @@
 package substancegen
 
+import (
+	"bytes"
+)
+
 /*GraphqlatorInterface placeholder comment */
 type SubstanceGenInterface interface {
 	GetObjectTypesFunc(dbType string, connectionString string, tableNames []string) map[string]GenObjectType
 	ResolveRelationshipsFunc(dbType string, connectionString string, tableNames []string, genObjects map[string]GenObjectType) map[string]GenObjectType
-	OutputCodeFunc(map[string]GenObjectType)
+	OutputCodeFunc(map[string]GenObjectType) bytes.Buffer
+	GenObjectTypeToStringFunc(GenObjectType, *bytes.Buffer)
+	GenObjectPropertyToStringFunc(GenObjectProperty, *bytes.Buffer)
+	GenObjectTagToStringFunc(GenObjectTag, *bytes.Buffer)
 }
 
 var substanceGenPlugins = make(map[string]SubstanceGenInterface)
@@ -14,13 +21,16 @@ func Register(pluginName string, pluginInterface SubstanceGenInterface) {
 	substanceGenPlugins[pluginName] = pluginInterface
 }
 
+type GenObjectTag map[string][]string
+
 /*GenObjectProperty placeholder comment */
 type GenObjectProperty struct {
 	ScalarName string
 	ScalarType string
 	IsList     bool
 	Nullable   bool
-	KeyType    string
+	KeyType    []string
+	Tags       GenObjectTag
 }
 
 /*GenObjectProperties placeholder comment */

--- a/substancegen/substancegen.go
+++ b/substancegen/substancegen.go
@@ -8,7 +8,7 @@ import (
 type SubstanceGenInterface interface {
 	GetObjectTypesFunc(dbType string, connectionString string, tableNames []string) map[string]GenObjectType
 	ResolveRelationshipsFunc(dbType string, connectionString string, tableNames []string, genObjects map[string]GenObjectType) map[string]GenObjectType
-	OutputCodeFunc(map[string]GenObjectType) bytes.Buffer
+	OutputCodeFunc(dbType string, connectionString string, gqlObjectTypes map[string]GenObjectType) bytes.Buffer
 	GenObjectTypeToStringFunc(GenObjectType, *bytes.Buffer)
 	GenObjectPropertyToStringFunc(GenObjectProperty, *bytes.Buffer)
 	GenObjectTagToStringFunc(GenObjectTag, *bytes.Buffer)
@@ -45,5 +45,5 @@ type GenObjectType struct {
 
 /*Generate placeholder comment */
 func Generate(generatorName string, dbType string, connectionString string, tableNames []string) {
-	substanceGenPlugins[generatorName].OutputCodeFunc(substanceGenPlugins[generatorName].GetObjectTypesFunc(dbType, connectionString, tableNames))
+	substanceGenPlugins[generatorName].OutputCodeFunc(dbType, connectionString, substanceGenPlugins[generatorName].GetObjectTypesFunc(dbType, connectionString, tableNames))
 }


### PR DESCRIPTION
This PR includes the changes to support generating a graphql-go server.

gqlschema.go has been renamed to graphlgo.go

Changes were made to postgres substance provider to remove prefixing `postgres://` to the connection string. Instead users are expected to input a full GORM ready connection string.