### PR TITLE
Feature/graphql type template

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 echo "pre-commit hook starting"
 if go test ./...; then
+    echo "pre commit-hook finished."
+    echo "go test return 0"
     exit 0
 else
     echo "Aborting commit go test failed"

--- a/substancegen/generators/gorm/gorm.go
+++ b/substancegen/generators/gorm/gorm.go
@@ -143,6 +143,8 @@ func GenObjectGormCrud(gqlObjectType substancegen.GenObjectType, buff *bytes.Buf
 	GenObjectGormDeleteFunc(gqlObjectType, buff)
 }
 
+/*GenObjectsGormCrud processes gqlObjectTypes map in sorted key order and calls GenObjectGormCrud
+This is done to produce predictable output*/
 func GenObjectsGormCrud(gqlObjectTypes map[string]substancegen.GenObjectType, buff *bytes.Buffer) {
 	keys := make([]string, 0)
 	for key := range gqlObjectTypes {

--- a/substancegen/generators/gorm/gorm.go
+++ b/substancegen/generators/gorm/gorm.go
@@ -61,12 +61,12 @@ func GenObjectGormReadFunc(gqlObjectType substancegen.GenObjectType, buff *bytes
 /*GenObjectGormUpdateFunc generates functions for basic CRUD Update using gorm and writes it to a buffer*/
 func GenObjectGormUpdateFunc(gqlObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
 	primaryKeyColumn := ""
+	//TODO: Lopp through all properties in alphabetic order (key sorted)
 	for _, propVal := range gqlObjectType.Properties {
 		if substancegen.StringInSlice("p", propVal.KeyType) || substancegen.StringInSlice("PRIMARY KEY", propVal.KeyType) {
 			primaryKeyColumn = propVal.ScalarNameUpper
 			break
-		}
-		if substancegen.StringInSlice("u", propVal.KeyType) || substancegen.StringInSlice("UNIQUE", propVal.KeyType) {
+		} else if substancegen.StringInSlice("u", propVal.KeyType) || substancegen.StringInSlice("UNIQUE", propVal.KeyType) {
 			primaryKeyColumn = propVal.ScalarNameUpper
 			break
 		}

--- a/substancegen/generators/gorm/gorm.go
+++ b/substancegen/generators/gorm/gorm.go
@@ -3,6 +3,7 @@ package gorm
 import (
 	"bytes"
 	"log"
+	"sort"
 	"text/template"
 
 	"github.com/ahmedalhulaibi/substance/substancegen"
@@ -121,4 +122,15 @@ func GenObjectGormCrud(gqlObjectType substancegen.GenObjectType, buff *bytes.Buf
 	GenObjectGormUpdateFunc(gqlObjectType, buff)
 
 	GenObjectGormDeleteFunc(gqlObjectType, buff)
+}
+
+func GenObjectsGormCrud(gqlObjectTypes map[string]substancegen.GenObjectType, buff *bytes.Buffer) {
+	keys := make([]string, 0)
+	for key := range gqlObjectTypes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		GenObjectGormCrud(gqlObjectTypes[key], buff)
+	}
 }

--- a/substancegen/generators/gorm/gorm.go
+++ b/substancegen/generators/gorm/gorm.go
@@ -70,6 +70,10 @@ func GenObjectGormUpdateFunc(gqlObjectType substancegen.GenObjectType, buff *byt
 			break
 		}
 	}
+	if primaryKeyColumn == "" {
+		log.Printf("No primary or unique key column found for object %s. Skipping Gorm update func.\n", gqlObjectType.Name)
+		return
+	}
 	var templateData = struct {
 		Name string
 		Key  string

--- a/substancegen/generators/gorm/gorm.go
+++ b/substancegen/generators/gorm/gorm.go
@@ -60,27 +60,26 @@ func GenObjectGormReadFunc(gqlObjectType substancegen.GenObjectType, buff *bytes
 
 /*GenObjectGormUpdateFunc generates functions for basic CRUD Update using gorm and writes it to a buffer*/
 func GenObjectGormUpdateFunc(gqlObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
-	primaryKeyColumn := ""
-	//TODO: Lopp through all properties in alphabetic order (key sorted)
-	for _, propVal := range gqlObjectType.Properties {
-		if substancegen.StringInSlice("p", propVal.KeyType) || substancegen.StringInSlice("PRIMARY KEY", propVal.KeyType) {
-			primaryKeyColumn = propVal.ScalarNameUpper
-			break
-		} else if substancegen.StringInSlice("u", propVal.KeyType) || substancegen.StringInSlice("UNIQUE", propVal.KeyType) {
-			primaryKeyColumn = propVal.ScalarNameUpper
+	searchKeyTypes := []string{"p", "PRIMARY KEY", "u", "UNIQUE"}
+	keyColumn := ""
+	for _, searchKeyType := range searchKeyTypes {
+		keyColumn = SearchForKeyColumnByKeyType(gqlObjectType, searchKeyType)
+		if keyColumn != "" {
 			break
 		}
 	}
-	if primaryKeyColumn == "" {
+
+	if keyColumn == "" {
 		log.Printf("No primary or unique key column found for object %s. Skipping Gorm update func.\n", gqlObjectType.Name)
 		return
 	}
+
 	var templateData = struct {
 		Name string
 		Key  string
 	}{
 		gqlObjectType.Name,
-		primaryKeyColumn,
+		keyColumn,
 	}
 
 	gormUpdateFuncTemplate := "\n\nfunc Update{{.Name}} (db *gorm.DB, old{{.Name}} {{.Name}}, new{{.Name}} {{.Name}}, result{{.Name}} *{{.Name}}) {\n\tvar oldResult{{.Name}} {{.Name}}\n\tdb.Where(&old{{.Name}}).First(&oldResult{{.Name}})\n\tif oldResult{{.Name}}.{{.Key}} == new{{.Name}}.{{.Key}} {\n\t\toldResult{{.Name}} = new{{.Name}}\n\t\tdb.Save(oldResult{{.Name}})\n\t}\n\tGet{{.Name}}(db, new{{.Name}}, result{{.Name}})\n}"
@@ -95,6 +94,26 @@ func GenObjectGormUpdateFunc(gqlObjectType substancegen.GenObjectType, buff *byt
 		log.Fatal("Execute: ", err1)
 		return
 	}
+}
+
+/*SearchForKeyColumnByKeyType returns a string containing the name of the column of a certain key type*/
+func SearchForKeyColumnByKeyType(gqlObjectType substancegen.GenObjectType, searchKeyType string) string {
+	keyColumn := ""
+	//Loop through all properties in alphabetic order (key sorted)
+	//This prevents different keys being identified across multiple runs using the same input data
+	propKeys := make([]string, 0)
+	for propKey := range gqlObjectType.Properties {
+		propKeys = append(propKeys, propKey)
+	}
+	sort.Strings(propKeys)
+	for _, propKey := range propKeys {
+		propVal := gqlObjectType.Properties[propKey]
+		if substancegen.StringInSlice(searchKeyType, propVal.KeyType) {
+			keyColumn = propVal.ScalarNameUpper
+			break
+		}
+	}
+	return keyColumn
 }
 
 /*GenObjectGormDeleteFunc generates functions for basic CRUD Delete using gorm and writes it to a buffer*/

--- a/substancegen/generators/gostruct/gostruct.go
+++ b/substancegen/generators/gostruct/gostruct.go
@@ -9,8 +9,8 @@ import (
 )
 
 /*GenObjectTypeToStructFunc takes a GenObjectType and writes it to a buffer as a go struct*/
-func GenObjectTypeToStructFunc(genObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
-	gostructTemplate := "\ntype {{.Name}} struct { {{range .Properties}}\n\t{{.ScalarNameUpper}}\t{{if .IsList}}[]{{end}}{{.ScalarType}}\t`{{range $index, $element := .Tags}}{{$index}}:\"{{range $element}}{{.}}{{end}}\" {{end}}`{{end}}\n}\n"
+func GenObjectTypeToStructFunc(genObjectTypes map[string]substancegen.GenObjectType, buff *bytes.Buffer) {
+	gostructTemplate := "{{range $key, $value := . }}\ntype {{.Name}} struct { {{range .Properties}}\n\t{{.ScalarNameUpper}}\t{{if .IsList}}[]{{end}}{{.ScalarType}}\t`{{range $index, $element := .Tags}}{{$index}}:\"{{range $element}}{{.}}{{end}}\" {{end}}`{{end}}\n}\n{{end}}"
 
 	tmpl := template.New("gostruct")
 	tmpl, err := tmpl.Parse(gostructTemplate)
@@ -18,7 +18,7 @@ func GenObjectTypeToStructFunc(genObjectType substancegen.GenObjectType, buff *b
 		log.Fatal("Parse: ", err)
 		return
 	}
-	err1 := tmpl.Execute(buff, genObjectType)
+	err1 := tmpl.Execute(buff, genObjectTypes)
 	if err1 != nil {
 		log.Fatal("Execute: ", err1)
 		return

--- a/substancegen/generators/gostruct/gostruct_test.go
+++ b/substancegen/generators/gostruct/gostruct_test.go
@@ -34,8 +34,9 @@ func TestGenObjectTypeToStructFunc(t *testing.T) {
 	}
 	newGenObjType.Properties["ShoppingList"].Tags = make(substancegen.GenObjectTag)
 	newGenObjType.Properties["ShoppingList"].Tags["json"] = append(newGenObjType.Properties["ShoppingList"].Tags["json"], "shoppingList")
-
-	GenObjectTypeToStructFunc(newGenObjType, &buff)
+	gqlObjects := make(map[string]substancegen.GenObjectType)
+	gqlObjects["Customer"] = newGenObjType
+	GenObjectTypeToStructFunc(gqlObjects, &buff)
 
 	var expectedBuff bytes.Buffer
 

--- a/substancegen/generators/graphqlgo/codeGeneration.go
+++ b/substancegen/generators/graphqlgo/codeGeneration.go
@@ -43,6 +43,7 @@ func (g Gql) GenerateGraphqlGoTypesFunc(gqlObjectTypes map[string]substancegen.G
 		}
 	}
 	graphqlTypesTemplate := `
+
 {{range $key, $value := . }}var {{.LowerName}}Type = graphql.NewObject(
 	graphql.ObjectConfig{
 		Name: "{{.Name}}",

--- a/substancegen/generators/graphqlgo/codeGeneration.go
+++ b/substancegen/generators/graphqlgo/codeGeneration.go
@@ -42,7 +42,7 @@ func (g Gql) GenerateGraphqlGoTypesFunc(gqlObjectTypes map[string]substancegen.G
 			}
 		}
 	}
-	graphqlTypesTemplate := "{{range $key, $value := . }}\nvar {{.LowerName}}Type = graphql.NewObject(\n\tgraphql.ObjectConfig{\n\t\tName: \"{{.Name}}\",\n\t\tFields: graphql.Fields{\n\t\t\t{{range .Properties}}\"{{.ScalarNameUpper}}\":&graphql.Field{\n\t\t\t\tType: {{.AltScalarType}}\n\t\t\t},\n\t\t\t{{end}}\n\t\t},\n\t},\n)\n{{end}}"
+	graphqlTypesTemplate := "{{range $key, $value := . }}\nvar {{.LowerName}}Type = graphql.NewObject(\n\tgraphql.ObjectConfig{\n\t\tName: \"{{.Name}}\",\n\t\tFields: graphql.Fields{\n\t\t\t{{range .Properties}}\"{{.ScalarNameUpper}}\":&graphql.Field{\n\t\t\t\tType: {{.AltScalarType}},\n\t\t\t},\n\t\t\t{{end}}\n\t\t},\n\t},\n)\n{{end}}"
 
 	tmpl := template.New("graphqlTypes")
 	tmpl, err := tmpl.Parse(graphqlTypesTemplate)

--- a/substancegen/generators/graphqlgo/codeGeneration.go
+++ b/substancegen/generators/graphqlgo/codeGeneration.go
@@ -42,7 +42,7 @@ func (g Gql) GenerateGraphqlGoTypesFunc(gqlObjectTypes map[string]substancegen.G
 			}
 		}
 	}
-	graphqlTypesTemplate := "{{range $key, $value := . }}var {{.LowerName}}Type = graphql.NewObject(\n\tgraphql.ObjectConfig{\n\t\tName: \"{{.Name}}\",\n\t\tFields: graphql.Fields{\n\t\t\t{{range .Properties}}\"{{.ScalarNameUpper}}\":&graphql.Field{\n\t\t\t\tType: {{.AltScalarType}}\n\t\t\t},\n\t\t\t{{end}}\n\t\t},\n\t},\n)\n{{end}}"
+	graphqlTypesTemplate := "{{range $key, $value := . }}\nvar {{.LowerName}}Type = graphql.NewObject(\n\tgraphql.ObjectConfig{\n\t\tName: \"{{.Name}}\",\n\t\tFields: graphql.Fields{\n\t\t\t{{range .Properties}}\"{{.ScalarNameUpper}}\":&graphql.Field{\n\t\t\t\tType: {{.AltScalarType}}\n\t\t\t},\n\t\t\t{{end}}\n\t\t},\n\t},\n)\n{{end}}"
 
 	tmpl := template.New("graphqlTypes")
 	tmpl, err := tmpl.Parse(graphqlTypesTemplate)

--- a/substancegen/generators/graphqlgo/codeGeneration.go
+++ b/substancegen/generators/graphqlgo/codeGeneration.go
@@ -57,45 +57,6 @@ func (g Gql) GenerateGraphqlGoTypesFunc(gqlObjectTypes map[string]substancegen.G
 	}
 }
 
-func (g Gql) GenGraphqlGoTypeFunc(gqlObjectType substancegen.GenObjectType, buff *bytes.Buffer) {
-	a := []rune(gqlObjectType.Name)
-	a[0] = unicode.ToLower(a[0])
-	gqlObjectTypeNameLowCamel := string(a)
-	buff.WriteString(fmt.Sprintf("\nvar %sType = graphql.NewObject(\n\tgraphql.ObjectConfig{\n\t\tName: \"%s\",\n\t\tFields: graphql.Fields{\n\t\t\t", gqlObjectTypeNameLowCamel, gqlObjectType.Name))
-
-	for _, property := range gqlObjectType.Properties {
-		g.GenGraphqlGoTypePropertyFunc(*property, buff)
-	}
-
-	buff.WriteString(fmt.Sprintf("\n\t\t},\n\t},\n)\n"))
-}
-
-func (g Gql) GenGraphqlGoTypePropertyFunc(gqlObjectProperty substancegen.GenObjectProperty, buff *bytes.Buffer) {
-	gqlPropertyTypeName := g.ResolveGraphqlGoFieldType(gqlObjectProperty)
-	buff.WriteString(fmt.Sprintf("\n\t\t\t\"%s\": &graphql.Field{\n\t\t\t\tType: %s,\n\t\t\t},", gqlObjectProperty.ScalarName, gqlPropertyTypeName))
-}
-
-func (g Gql) ResolveGraphqlGoFieldType(gqlObjectProperty substancegen.GenObjectProperty) string {
-	var gqlPropertyTypeName string
-
-	if gqlObjectProperty.IsObjectType {
-		a := []rune(inflection.Singular(gqlObjectProperty.ScalarName))
-		a[0] = unicode.ToLower(a[0])
-		gqlPropertyTypeName = fmt.Sprintf("%sType", string(a))
-	} else {
-		gqlPropertyTypeName = g.GraphqlDataTypes[gqlObjectProperty.ScalarType]
-	}
-
-	if gqlObjectProperty.IsList {
-		gqlPropertyTypeName = fmt.Sprintf("graphql.NewList(%s)", gqlPropertyTypeName)
-	}
-
-	if !gqlObjectProperty.Nullable {
-		gqlPropertyTypeName = fmt.Sprintf("graphql.NewNonNull(%s)", gqlPropertyTypeName)
-	}
-	return gqlPropertyTypeName
-}
-
 func GenGraphqlGoMainFunc(dbType string, connectionString string, gqlObjectTypes map[string]substancegen.GenObjectType, buff *bytes.Buffer) {
 	buff.WriteString(fmt.Sprintf("\nvar DB *gorm.DB\n\n"))
 	buff.WriteString(fmt.Sprintf("\nfunc main() {\n\n\tDB, _ = gorm.Open(\"%s\",\"%s\")\n\tdefer DB.Close()\n\n\t", dbType, connectionString))

--- a/substancegen/generators/graphqlgo/codeGeneration.go
+++ b/substancegen/generators/graphqlgo/codeGeneration.go
@@ -93,7 +93,7 @@ func GenGraphqlGoFieldsFunc(gqlObjectTypes map[string]substancegen.GenObjectType
 
 func GenGraphqlGoSampleQuery(gqlObjectTypes map[string]substancegen.GenObjectType) bytes.Buffer {
 	var buff bytes.Buffer
-	graphqlQueryTemplate := `{{.Name}} { {{range .Properties}}{{if not .IsObjectType}}{{.ScalarName}},{{end}} {{end}}},`
+	graphqlQueryTemplate := `{{range $key, $value := . }}{{.Name}} { {{range .Properties}}{{if not .IsObjectType}}{{.ScalarName}},{{end}} {{end}}},{{end}}`
 	tmpl := template.New("graphqlQuery")
 	tmpl, err := tmpl.Parse(graphqlQueryTemplate)
 	if err != nil {
@@ -101,13 +101,12 @@ func GenGraphqlGoSampleQuery(gqlObjectTypes map[string]substancegen.GenObjectTyp
 		return buff
 	}
 	//print schema
-	for _, value := range gqlObjectTypes {
-		err1 := tmpl.Execute(&buff, value)
-		if err1 != nil {
-			log.Fatal("Execute: ", err1)
-			return buff
-		}
+	err1 := tmpl.Execute(&buff, gqlObjectTypes)
+	if err1 != nil {
+		log.Fatal("Execute: ", err1)
+		return buff
 	}
+
 	bufferString := buff.String()
 	bufferString = strings.Replace(bufferString, " ", "", -1)
 	buff.Reset()

--- a/substancegen/generators/graphqlgo/codeGeneration.go
+++ b/substancegen/generators/graphqlgo/codeGeneration.go
@@ -118,7 +118,7 @@ func GenGraphqlGoSampleQuery(gqlObjectTypes map[string]substancegen.GenObjectTyp
 func OutputGraphqlSchema(gqlObjectTypes map[string]substancegen.GenObjectType) bytes.Buffer {
 	var buff bytes.Buffer
 
-	graphqlSchemaTemplate := "type {{.Name}} {\n {{range .Properties}}\t{{.ScalarName}}: {{if .IsList}}[{{.ScalarType}}]{{else}}{{.ScalarType}}{{end}}{{if .Nullable}}{{else}}!{{end}}\n{{end}}}\n"
+	graphqlSchemaTemplate := "{{range $key, $value := . }}type {{.Name}} {\n {{range .Properties}}\t{{.ScalarName}}: {{if .IsList}}[{{.ScalarType}}]{{else}}{{.ScalarType}}{{end}}{{if .Nullable}}{{else}}!{{end}}\n{{end}}}\n{{end}}"
 	tmpl := template.New("graphqlSchema")
 	tmpl, err := tmpl.Parse(graphqlSchemaTemplate)
 	if err != nil {
@@ -126,12 +126,11 @@ func OutputGraphqlSchema(gqlObjectTypes map[string]substancegen.GenObjectType) b
 		return buff
 	}
 	//print schema
-	for _, value := range gqlObjectTypes {
-		err1 := tmpl.Execute(&buff, value)
-		if err1 != nil {
-			log.Fatal("Execute: ", err1)
-			return buff
-		}
+	err1 := tmpl.Execute(&buff, gqlObjectTypes)
+	if err1 != nil {
+		log.Fatal("Execute: ", err1)
+		return buff
 	}
+
 	return buff
 }

--- a/substancegen/generators/graphqlgo/codeGeneration.go
+++ b/substancegen/generators/graphqlgo/codeGeneration.go
@@ -42,21 +42,7 @@ func (g Gql) GenerateGraphqlGoTypesFunc(gqlObjectTypes map[string]substancegen.G
 			}
 		}
 	}
-	graphqlTypesTemplate := `
-
-{{range $key, $value := . }}var {{.LowerName}}Type = graphql.NewObject(
-	graphql.ObjectConfig{
-		Name: "{{.Name}}",
-		Fields: graphql.Fields{
-			{{range .Properties}}"{{.ScalarNameUpper}}":&graphql.Field{
-				Type: {{.AltScalarType}}
-			},
-			{{end}}
-		},
-	},
-){{end}}
-
-`
+	graphqlTypesTemplate := "{{range $key, $value := . }}var {{.LowerName}}Type = graphql.NewObject(\n\tgraphql.ObjectConfig{\n\t\tName: \"{{.Name}}\",\n\t\tFields: graphql.Fields{\n\t\t\t{{range .Properties}}\"{{.ScalarNameUpper}}\":&graphql.Field{\n\t\t\t\tType: {{.AltScalarType}}\n\t\t\t},\n\t\t\t{{end}}\n\t\t},\n\t},\n)\n{{end}}"
 
 	tmpl := template.New("graphqlTypes")
 	tmpl, err := tmpl.Parse(graphqlTypesTemplate)

--- a/substancegen/generators/graphqlgo/codeGeneration.go
+++ b/substancegen/generators/graphqlgo/codeGeneration.go
@@ -47,7 +47,7 @@ func (g Gql) GenerateGraphqlGoTypesFunc(gqlObjectTypes map[string]substancegen.G
 	graphql.ObjectConfig{
 		Name: "{{.Name}}",
 		Fields: graphql.Fields{
-			{{range .Properties}}"{{.ScalarNameUpper}":&graphql.Field{
+			{{range .Properties}}"{{.ScalarNameUpper}}":&graphql.Field{
 				Type: {{.AltScalarType}}
 			},
 			{{end}}

--- a/substancegen/generators/graphqlgo/codeGeneration_test.go
+++ b/substancegen/generators/graphqlgo/codeGeneration_test.go
@@ -120,7 +120,7 @@ func TestGenGraphqlGoFieldsFunc(t *testing.T) {
 	var expectedBuff bytes.Buffer
 
 	expectedBuff.WriteString(`
-	var Fields = graphql.Fields{
+	var Fields = graphql.Fields{ 
 		"Customer": &graphql.Field{
 			Type: customerType,
 			Resolve: func(p graphql.ResolveParams) (interface{}, error) {

--- a/substancegen/generators/graphqlgo/graphqlgo.go
+++ b/substancegen/generators/graphqlgo/graphqlgo.go
@@ -46,8 +46,8 @@ func (g Gql) OutputCodeFunc(dbType string, connectionString string, gqlObjectTyp
 	g.GenPackageImports(dbType, &buff)
 	//print schema
 	substancegen.AddJSONTagsToProperties(gqlObjectTypes)
+	gostruct.GenObjectTypeToStructFunc(gqlObjectTypes, &buff)
 	for _, value := range gqlObjectTypes {
-		gostruct.GenObjectTypeToStructFunc(value, &buff)
 		gorm.GenGormObjectTableNameOverrideFunc(value, &buff)
 	}
 	g.GenerateGraphqlGoTypesFunc(gqlObjectTypes, &buff)

--- a/substancegen/generators/graphqlgo/graphqlgo.go
+++ b/substancegen/generators/graphqlgo/graphqlgo.go
@@ -49,8 +49,8 @@ func (g Gql) OutputCodeFunc(dbType string, connectionString string, gqlObjectTyp
 	for _, value := range gqlObjectTypes {
 		gostruct.GenObjectTypeToStructFunc(value, &buff)
 		gorm.GenGormObjectTableNameOverrideFunc(value, &buff)
-		g.GenGraphqlGoTypeFunc(value, &buff)
 	}
+	g.GenerateGraphqlGoTypesFunc(gqlObjectTypes, &buff)
 	buff.WriteString(GraphqlGoExecuteQueryFunc)
 	graphqlFieldsBuff := GenGraphqlGoFieldsFunc(gqlObjectTypes)
 	buff.Write(graphqlFieldsBuff.Bytes())

--- a/substancegen/substancegen.go
+++ b/substancegen/substancegen.go
@@ -40,7 +40,8 @@ This will require changes in generators/gostruct_test.go*/
 type GenObjectProperty struct {
 	ScalarName      string `json:"scalarName"`
 	ScalarNameUpper string
-	ScalarType      string       `json:"scalarType"`
+	ScalarType      string `json:"scalarType"`
+	AltScalarType   string
 	IsList          bool         `json:"isList"`
 	Nullable        bool         `json:"nullable"`
 	KeyType         []string     `json:"keyType"`


### PR DESCRIPTION
#14 Go templates are now used for majority of generator code. This ensures that the output code is written the exact same way each time. 

#16 If no primary or unique key is present for a given object type, no GormUpdate function will be created.
